### PR TITLE
krb5-1.12.4: autoconf support for cross-compilation.

### DIFF
--- a/krb5/src/aclocal.m4
+++ b/krb5/src/aclocal.m4
@@ -724,7 +724,7 @@ AC_TRY_RUN([
 #include <regex.h>
 regex_t x; regmatch_t m;
 int main() { return regcomp(&x,"pat.*",0) || regexec(&x,"pattern",1,&m,0); }
-], ac_cv_func_regcomp=yes, ac_cv_func_regcomp=no, AC_MSG_ERROR([Cannot test regcomp when cross compiling]))])
+], ac_cv_func_regcomp=yes, ac_cv_func_regcomp=no, AC_MSG_WARN([Cannot test regcomp when cross compiling]); ac_cv_func_regcomp=yes)]
 AC_MSG_RESULT($ac_cv_func_regcomp)
 test $ac_cv_func_regcomp = yes && AC_DEFINE(HAVE_REGCOMP,1,[Define if regcomp exists and functions])
 dnl
@@ -1586,7 +1586,7 @@ void foo2() __attribute__((destructor));
 void foo2() { unlink("conftest.2"); }
 int main () { return 0; }],
 [test -r conftest.1 || a=yes
-test -r conftest.2 || b=yes], , AC_MSG_ERROR(Cannot test for constructor/destructor support when cross compiling))
+test -r conftest.2 || b=yes], , AC_MSG_WARN(Cannot test for constructor/destructor support when cross compiling); a=yes; b=yes)
 case $krb5_cv_host in
 *-*-aix4.*)
 	# Under AIX 4.3.3, at least, shared library destructor functions

--- a/krb5/src/configure
+++ b/krb5/src/configure
@@ -5615,7 +5615,9 @@ a=no
 b=no
 # blindly assume we have 'unlink'...
 if test "$cross_compiling" = yes; then :
-  as_fn_error $? "Cannot test for constructor/destructor support when cross compiling" "$LINENO" 5
+  as_fn_warn $? "Cannot test for constructor/destructor support when cross compiling" "$LINENO" 5
+  a=yes
+  b=yes
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -7362,7 +7364,8 @@ if ${ac_cv_func_regcomp+:} false; then :
 else
 
 if test "$cross_compiling" = yes; then :
-  as_fn_error $? "Cannot test regcomp when cross compiling" "$LINENO" 5
+  as_fn_warn $? "Cannot test regcomp when cross compiling" "$LINENO" 5
+  ac_cv_func_regcomp=yes
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -11120,7 +11123,8 @@ if ${ac_cv_printf_positional+:} false; then :
 else
 
 if test "$cross_compiling" = yes; then :
-  as_fn_error $? "Cannot test for printf positional argument support when cross compiling" "$LINENO" 5
+  as_fn_warn $? "Cannot test for printf positional argument support when cross compiling" "$LINENO" 5
+  ac_cv_printf_positional=yes
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */

--- a/krb5/src/configure.in
+++ b/krb5/src/configure.in
@@ -818,7 +818,7 @@ int main () {
 }],
   ac_cv_printf_positional=yes,
   ac_cv_printf_positional=no,
-  AC_MSG_ERROR([Cannot test for printf positional argument support when cross compiling]))])
+  AC_MSG_WARN([Cannot test for printf positional argument support when cross compiling]); ac_cv_printf_positional=yes)])
 # Nothing for autoconf.h for now.
 AC_MSG_RESULT($ac_cv_printf_positional)
 


### PR DESCRIPTION
Gracefully fail and use sensible defaults when cross-compiling in
situations where the autoconf errors out today.
