### PR TITLE
Add APIs to configure nsswitch and pam

### DIFF
--- a/domainjoin/libdomainjoin/include/djapi.h
+++ b/domainjoin/libdomainjoin/include/djapi.h
@@ -75,6 +75,26 @@ DJUnjoinDomain(
     PCSTR pszPassword
     );
 
+DWORD
+DJConfigureNSSwitch(
+    VOID
+    );
+
+DWORD
+DJUnconfigureNSSwitch(
+    VOID
+    );
+
+DWORD
+DJConfigurePAM(
+    VOID
+    );
+
+DWORD
+DJUnconfigurePAM(
+    VOID
+    );
+
 VOID
 DJFreeMemory(
     PVOID pMemory

--- a/domainjoin/libdomainjoin/include/domainjoin.h
+++ b/domainjoin/libdomainjoin/include/domainjoin.h
@@ -43,6 +43,7 @@
 #include "djparsehosts.h"
 #include "djkrb5conf.h"
 #include "djnsswitch.h"
+#include "djpamconf.h"
 #include "djdaemonmgr.h"
 #include "djmethodcfg.h"
 #include "djlogincfg.h"

--- a/domainjoin/libdomainjoin/src/djapi.c
+++ b/domainjoin/libdomainjoin/src/djapi.c
@@ -190,6 +190,96 @@ cleanup:
 }
 
 DWORD
+DJConfigureNSSwitch(
+    VOID
+    )
+{
+    return ConfigureNameServiceSwitch();
+}
+
+DWORD
+DJUnconfigureNSSwitch(
+    VOID
+    )
+{
+    return UnConfigureNameServiceSwitch();
+}
+
+DWORD
+DJConfigurePAM(
+    VOID
+    )
+{
+    DWORD dwError = ERROR_SUCCESS;
+    PCSTR testPrefix = NULL;
+    JoinProcessOptions options;
+
+    LWException *exc = NULL;
+
+    DJZeroJoinProcessOptions(&options);
+    options.joiningDomain = TRUE;
+
+    LW_TRY(&exc, DJInitModuleStates(&options, &LW_EXC));
+
+    LW_TRY(&exc, DJNewConfigurePamForADLogin(
+                    testPrefix,
+                    &options,
+                    options.warningCallback,
+                    TRUE,
+                    &LW_EXC
+                    ));
+
+cleanup:
+
+    DJFreeJoinProcessOptions(&options);
+
+    if (!LW_IS_OK(exc))
+    {
+        dwError = exc->code;
+        LWHandle(&exc);
+    }
+
+    return dwError;
+}
+
+DWORD
+DJUnconfigurePAM(
+    VOID
+    )
+{
+    DWORD dwError = ERROR_SUCCESS;
+    PCSTR testPrefix = NULL;
+    JoinProcessOptions options;
+
+    LWException *exc = NULL;
+
+    DJZeroJoinProcessOptions(&options);
+    options.joiningDomain = FALSE;
+
+    LW_TRY(&exc, DJInitModuleStates(&options, &LW_EXC));
+
+    LW_TRY(&exc, DJNewConfigurePamForADLogin(
+                    testPrefix,
+                    &options,
+                    options.warningCallback,
+                    FALSE,
+                    &LW_EXC
+                    ));
+
+cleanup:
+
+    DJFreeJoinProcessOptions(&options);
+
+    if (!LW_IS_OK(exc))
+    {
+        dwError = exc->code;
+        LWHandle(&exc);
+    }
+
+    return dwError;
+}
+
+DWORD
 DJUnjoinDomain(
     PCSTR pszUsername,
     PCSTR pszPassword


### PR DESCRIPTION
Automatic Merge of CS: 65843 from likewise-stable to main

Automation: automerge=likewise-stable:main:65843
Testing Done: [Refer to original change.]
Bug Number: 1483154
Reviewed by: rlohia
Approved by: krishnag
Mailto: vmware-lwis

Original Submittor:   snambakam
Original Description:
| Add APIs to configure nsswitch and pam
|
| QA Notes:
| Testing Done: sandbox build https://buildweb.eng.vmware.com/sb/5787115/
| Documentation Notes:
| Bug Number: 1483154
| Reviewed by: rlohia
| Approved by: krishnag
| Mailto: vmware-lwis
| # Set "Merge to" values below to YES, SVS, NO, or MANUAL.
| # If you're unsure, ask your manager or your peers, DO NOT guess.
| Merge to: main: YES #

[git-p4: depot-paths = "//public/vmware-likewise-open-6-1/main/likewise-v6.1/": change = 65844]
