### PR TITLE
When configuring PAM, don't initialize other modules

### DIFF
--- a/domainjoin/libdomainjoin/src/djapi.c
+++ b/domainjoin/libdomainjoin/src/djapi.c
@@ -212,26 +212,18 @@ DJConfigurePAM(
 {
     DWORD dwError = ERROR_SUCCESS;
     PCSTR testPrefix = NULL;
-    JoinProcessOptions options;
 
     LWException *exc = NULL;
 
-    DJZeroJoinProcessOptions(&options);
-    options.joiningDomain = TRUE;
-
-    LW_TRY(&exc, DJInitModuleStates(&options, &LW_EXC));
-
     LW_TRY(&exc, DJNewConfigurePamForADLogin(
                     testPrefix,
-                    &options,
-                    options.warningCallback,
+                    NULL,
+                    NULL,
                     TRUE,
                     &LW_EXC
                     ));
 
 cleanup:
-
-    DJFreeJoinProcessOptions(&options);
 
     if (!LW_IS_OK(exc))
     {
@@ -249,26 +241,18 @@ DJUnconfigurePAM(
 {
     DWORD dwError = ERROR_SUCCESS;
     PCSTR testPrefix = NULL;
-    JoinProcessOptions options;
 
     LWException *exc = NULL;
 
-    DJZeroJoinProcessOptions(&options);
-    options.joiningDomain = FALSE;
-
-    LW_TRY(&exc, DJInitModuleStates(&options, &LW_EXC));
-
     LW_TRY(&exc, DJNewConfigurePamForADLogin(
                     testPrefix,
-                    &options,
-                    options.warningCallback,
+                    NULL,
+                    NULL,
                     FALSE,
                     &LW_EXC
                     ));
 
 cleanup:
-
-    DJFreeJoinProcessOptions(&options);
 
     if (!LW_IS_OK(exc))
     {


### PR DESCRIPTION
Automatic Merge of CS: 66053 from likewise-stable to main

Automation: automerge=likewise-stable:main:66053
Testing Done: [Refer to original change.]
Bug Number: 1483154
Reviewed by: brownj
Approved by: krishnag
Mailto: vmidentity-checkins

Original Submittor:   snambakam
Original Description:
| When configuring PAM, don't initialize other modules
|
| QA Notes:
| Testing Done: sandbox build https://reviewboard.eng.vmware.com/r/849564/
| tested PAM configuration through invoking the new PAM API
| Documentation Notes:
| Bug Number: 1483154
| Reviewed by: brownj
| Approved by: krishnag
| Mailto: vmidentity-checkins
| # Set "Merge to" values below to YES, SVS, NO, or MANUAL.
| # If you're unsure, ask your manager or your peers, DO NOT guess.
| Merge to: main: YES #

[git-p4: depot-paths = "//public/vmware-likewise-open-6-1/main/likewise-v6.1/": change = 66054]
