### PR TITLE
Fix authenticated RPC hang / SPNEGO memory leak

### DIFF
--- a/dcerpc/ncklib/gssauthcn.c
+++ b/dcerpc/ncklib/gssauthcn.c
@@ -539,6 +539,7 @@ INTERNAL boolean32 rpc__gssauth_cn_cred_changed
 	unsigned32		*st;
 #endif
 {
+	boolean32 sec_changed = false;
 	CODING_ERROR(st);
 	RPC_DBG_PRINTF(rpc_e_dbg_auth, RPC_C_CN_DBG_AUTH_ROUTINE_TRACE,
 		("(rpc__gssauth_cn_cred_changed)\n"));
@@ -560,7 +561,18 @@ INTERNAL boolean32 rpc__gssauth_cn_cred_changed
 	 * Assume that cred is already valid.
 	 */
 	*st = rpc_s_ok;
-	return false;
+
+	/*
+	 * This credential must change if the there is an error status present
+	 * in the credential's context. This credential handle is invalid,
+	 * as the previous authentication failed.
+	 */
+	if (sec->sec_status != rpc_s_ok)
+	{
+	    sec_changed = true;
+	    *st = sec->sec_status;
+	}
+	return sec_changed;
 }
 
 /*****************************************************************************/
@@ -951,7 +963,7 @@ INTERNAL int rpc__gssauth_verify_server_token
 				      NULL,
 				      NULL);
 	if (gss_rc != GSS_S_COMPLETE) {
-		return gss_rc;
+	    return gss_rc;
 	}
 
 	return GSS_S_COMPLETE;

--- a/krb5/src/lib/gssapi/spnego/spnego_mech.c
+++ b/krb5/src/lib/gssapi/spnego/spnego_mech.c
@@ -948,7 +948,7 @@ spnego_gss_init_sec_context(
 	gss_buffer_t mechtok_in, mechListMIC_in, mechListMIC_out;
 	gss_buffer_desc mechtok_out = GSS_C_EMPTY_BUFFER;
 	spnego_gss_cred_id_t spcred = NULL;
-	spnego_gss_ctx_id_t spnego_ctx = NULL;
+	spnego_gss_ctx_id_t spnego_ctx = (spnego_gss_ctx_id_t)*context_handle;
 
 	dsyslog("Entering init_sec_context\n");
 
@@ -1011,7 +1011,6 @@ spnego_gss_init_sec_context(
 
 	/* Step 2: invoke the selected or optimistic mechanism's
 	 * gss_init_sec_context function, if it didn't complete previously. */
-	spnego_ctx = (spnego_gss_ctx_id_t)*context_handle;
 	if (!spnego_ctx->mech_complete) {
 		ret = init_ctx_call_init(
 			minor_status, spnego_ctx, spcred,


### PR DESCRIPTION
This fixes another authenticated RPC hang. This occurs when an incorrect user ID (UPN) is specified in the authentication information. The created GSSAPI context is invalid, but that information is lost, so in subsequent RPC calls with this binding handle, the RPC hangs, because the rpc__cn_assoc_alter_context() state is out of sync with the GSSAPI credential.

After fixing the hang, a memory leak in GSSAPI/SPNEGO was found. This is fixed in this submit.
