### PR TITLE
Update security.c

### DIFF
--- a/lwmsg/src/security.c
+++ b/lwmsg/src/security.c
@@ -105,7 +105,7 @@ lwmsg_security_token_equal(
     {
         return LWMSG_TRUE;
     }
-    else if (token->tclass != token->tclass)
+    else if (token->tclass != other->tclass)
     {
         return LWMSG_FALSE;
     }


### PR DESCRIPTION
Noticed when this issue was triggered in gcc-6.3 
../lwmsg/src/security.c:108:28: error: self-comparison always evaluates to false [-Werror=tautological-compare]                                       
 else if (token->tclass != token->tclass)