### PR TITLE
Fix build warnings/errors with gcc 7.3

### DIFF
--- a/dcerpc/ncklib/cnxfer.c
+++ b/dcerpc/ncklib/cnxfer.c
@@ -364,7 +364,7 @@ PRIVATE void rpc__cn_add_new_iovector_elmt
          * Then adjust iovector so that we have only 2 elements:
          * the header plus the current stub data.
          */
-        if (RPC_CN_CREP_IOVLEN (call_rep) > (call_rep->sec != NULL) ? 3 : 2)
+        if (RPC_CN_CREP_IOVLEN (call_rep) > ((call_rep->sec != NULL) ? 3 : 2))
         {
             /*
              * rpc__cn_dealloc_buffered_data will always skip the

--- a/lsass/server/auth-providers/ad-open-provider/join/join.c
+++ b/lsass/server/auth-providers/ad-open-provider/join/join.c
@@ -732,7 +732,7 @@ LsaJoinDomainInternal(
                sizeof(pwszMachinePassword)/sizeof(pwszMachinePassword[0]));
     BAIL_ON_LSA_ERROR(dwError);
 
-    if (pwszMachinePassword[0] == '\0')
+    if (pwszMachinePassword[0] == NULL || *pwszMachinePassword[0] == '\0')
     {
         BAIL_ON_NT_STATUS(STATUS_INTERNAL_ERROR);
     }

--- a/lwreg/server/providers/sqlite/sqliteapi.c
+++ b/lwreg/server/providers/sqlite/sqliteapi.c
@@ -1651,7 +1651,7 @@ SqliteDeleteTreeInternal_inlock_inDblock(
     for (iCount = 0; iCount < subKeyCount.dwSubKeyCount; iCount++)
     {
         dwSubKeyLen = MAX_KEY_LENGTH;
-        memset(psubKeyName, 0, MAX_KEY_LENGTH);
+        memset(psubKeyName, 0, MAX_KEY_LENGTH * sizeof(psubKeyName[0]));
 
         status = SqliteEnumKeyEx_inDblock(Handle,
                                   hKey,

--- a/lwreg/shell/export.c
+++ b/lwreg/shell/export.c
@@ -346,7 +346,7 @@ ProcessExportedKeyInfo(
 
     for (iCount = 0; iCount < dwValuesCount; iCount++)
     {
-        memset(pwszValueName, 0, MAX_KEY_LENGTH);
+        memset(pwszValueName, 0, MAX_KEY_LENGTH * sizeof(pwszValueName[0]));
         dwValueNameLen = MAX_KEY_LENGTH;
         memset(value, 0, dwValueLenMax);
         dwValueLen = dwValueLenMax;

--- a/lwreg/utils/fileutils.c
+++ b/lwreg/utils/fileutils.c
@@ -866,7 +866,7 @@ RegGetMatchingFilePathsInFolder(
     {
         PSTR pszPath;
         struct __PATHNODE *pNext;
-    } PATHNODE, *PPATHNODE;
+    } *PPATHNODE;
 
     DWORD dwError = 0;
     DIR* pDir = NULL;


### PR DESCRIPTION
           [compile] lwreg/utils/fileutils.c (host/x86_64)
../lwreg/utils/fileutils.c: In function 'RegGetMatchingFilePathsInFolder':
../lwreg/utils/fileutils.c:869:7: warning: typedef 'PATHNODE' locally defined but not used [-Wunused-local-typedefs]
     } PATHNODE, *PPATHNODE;
       ^~~~~~~~

          [compile] lwreg/server/providers/sqlite/sqliteapi.c (host/x86_64)
../lwreg/server/providers/sqlite/sqliteapi.c: In function 'SqliteDeleteTreeInternal_inlock_inDblock':
../lwreg/server/providers/sqlite/sqliteapi.c:1654:9: error: 'memset' used with length equal to number of elements without multiplication by element size [-Werror=memset-elt-size]
         memset(psubKeyName, 0, MAX_KEY_LENGTH);
         ^~~~~~

           [compile] lwreg/shell/export.c (host/x86_64)
../lwreg/shell/export.c: In function 'ProcessExportedKeyInfo':
../lwreg/shell/export.c:349:9: error: 'memset' used with length equal to number of elements without multiplication by element size [-Werror=memset-elt-size]
         memset(pwszValueName, 0, MAX_KEY_LENGTH);
         ^~~~~~

           [compile] dcerpc/ncklib/cnxfer.c (host/x86_64)
../dcerpc/ncklib/cnxfer.c: In function 'rpc__cn_add_new_iovector_elmt':
../dcerpc/ncklib/cnxfer.c:367:73: error: ?: using integer constants in boolean context, the expression will always evaluate to 'true' [-Werror=int-in-bool-context]
         if (RPC_CN_CREP_IOVLEN (call_rep) > (call_rep->sec != NULL) ? 3 : 2)

           [compile] lsass/server/auth-providers/ad-open-provider/join/join.c (host/x86_64)
../lsass/server/auth-providers/ad-open-provider/join/join.c: In function 'LsaJoinDomainInternal':
../lsass/server/auth-providers/ad-open-provider/join/join.c:735:32: error: comparison between pointer and zero character constant [-Werror=pointer-compare]
     if (pwszMachinePassword[0] == '\0')
                                ^~
../lsass/server/auth-providers/ad-open-provider/join/join.c:735:9: note: did you mean to dereference the pointer?
     if (pwszMachinePassword[0] == '\0')
         ^

cc1: all warnings being treated as errors

Signed-off-by: Srivatsa S. Bhat <srivatsa@csail.mit.edu>